### PR TITLE
Address more questions from users

### DIFF
--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -16,6 +16,7 @@ title: "FAQ and Troubleshooting"
     +   [Using a fast (de)cloner glitch Pokémon to delete Pokémon](../general-faq.md#using-a-fast-decloner-glitch-pokémon-to-delete-pokémon)
     +   [Using group selection to clear invisible bad eggs](../general-faq.md#using-group-selection-to-clear-invisible-bad-eggs)
     +   [Using group selection to mass clear invisible bad eggs and ghost data](../general-faq.md#using-group-selection-to-mass-clear-invisible-bad-eggs-and-ghost-data)
+*   [My Pokémon/Egg is disappearing when I move them](../general-faq.md#my-pokémonegg-is-disappearing-when-i-move-them)
 *   [How can I make my own ACE code?](../general-faq.md#how-can-i-make-my-own-ace-code)
 
 ## Pokémon FireRed and LeafGreen

--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -24,6 +24,7 @@ title: "FAQ and Troubleshooting"
 *   [The 0x0351 mail did not work](../frlg-faq.md#the-0x0351-mail-did-not-work)
 *   [My HOCK turned into a bad egg](../frlg-faq.md#my-hock-turned-into-a-bad-egg)
 *   [Bad eggs are appearing in Box 13](../frlg-faq.md#bad-eggs-are-appearing-in-box-13)
+*   [The glitch Pokémon has a different box sprite](../frlg-faq.md#the-glitch-pokémon-has-a-different-icon)
 *   [I am playing on the Switch rerelease and the codes do not work!](../frlg-faq.md#i-am-playing-on-the-switch-rerelease-and-the-codes-do-not-work)
     +   [Codes that will need a specific Switch rerelease version](../frlg-faq.md#codes-that-will-need-a-specific-switch-rerelease-version)
     +   [Code adjustments needed for Switch rereleases](../frlg-faq.md#code-adjustments-needed-for-switch-rereleases)

--- a/content/frlg-faq.md
+++ b/content/frlg-faq.md
@@ -60,6 +60,17 @@ minimise the opportunities of running the game code that performs the
 unwanted corruptions to Box 13. For this prevention technique to work,
 you should store 0x0351 in a box other than Box 13 or Box 14.
 
+## The glitch Pokémon has a different box sprite
+
+That is expected when viewing these glitch Pokémon in FireRed and LeafGreen.
+As long as the glitch Pokémon has the correct species name, then you can
+be sure that you have the correct glitch Pokémon.
+
+Glitch Pokémon will usually steal the box sprite of some other Pokémon
+sprite within the same box or the party. They can usually still be
+identified by the sprite appearing with the wrong colors. At other times
+they may appear with the question mark sprite.
+
 ## I am playing on the Switch rerelease and the codes do not work!
 
 As of 1st March 2026, these Switch rereleases are very recent and have many odd quirks that makes some existing codes for the original FireRed and LeafGreen incompatible.

--- a/content/frlg-jpn-main-route.md
+++ b/content/frlg-jpn-main-route.md
@@ -408,6 +408,15 @@ After performing the swap, your game should not crash. If that is so, then you h
 
 If you see this, that means the code worked, and you have ACE set up in Japanese FireRed or LeafGreen. You can trigger ACE at any time with this glitch Pokémon by setting the correct box names for your code beforehand then performing the aforementioned swapping with **this** glitch Pokémon.
 
+<div class="admonition note" markdown="block">
+<p class="admonition-title">Note</p>
+
+The glitch Pokémon’s icon may not appear exactly as shown in the screenshots, this is normal.
+Glitch Pokémon in FireRed and LeafGreen will usually appear either as another Pokémon in the boxes with a different color palette, or as a question mark.
+More information about this can be found at [this FAQ](frlg-faq.md#the-glitch-pokémon-has-a-different-box-sprite).
+
+</div>
+
 ### In case of failure
 
 If a **bad egg** appeared in party slot 3, or the game **crashed** after performing the swap, or **nothing** happened after performing the swap, it could be caused by the following:

--- a/content/frlg-jpn-nido-route.md
+++ b/content/frlg-jpn-nido-route.md
@@ -133,6 +133,15 @@ Make sure you save **here**, and do not perform further saves until instructed s
 
 That is it, you have setup ACE in Japanese LeafGreen!
 
+<div class="admonition note" markdown="block">
+<p class="admonition-title">Note</p>
+
+The glitch Pokémon’s icon may not appear exactly as shown in the screenshots, this is normal.
+Glitch Pokémon in FireRed and LeafGreen will usually appear either as another Pokémon in the boxes with a different color palette, or as a question mark.
+More information about this can be found at [this FAQ](frlg-faq.md#the-glitch-pokémon-has-a-different-box-sprite).
+
+</div>
+
 ### In case of failure
 
 If a **bad egg** appeared in party slot 3, or the game crashed after performing the swap, or nothing happened after performing the swap, it could be caused by the following:

--- a/content/frlg-non-jpn-other-empty-slot-routes.md
+++ b/content/frlg-non-jpn-other-empty-slot-routes.md
@@ -21,6 +21,14 @@ In these routes, you will be setting up arbitrary code execution in non-Japanese
 
 **Make sure that Box 3, Slot 1 is empty before performing these instructions**
 
+<div class="admonition note" markdown="block">
+<p class="admonition-title">Note</p>
+
+These glitch Pokémon will not have `hasSpecies` set, they will disappear if you include them in a group selection.
+More information can be found at [this FAQ](general-faq.md#my-pokémonegg-is-disappearing-when-i-move-them).
+
+</div>
+
 ### English and Italian FireRed and LeafGreen
 
 In this section, we will be creating glitch species 0x1453 on English versions or 0x1457 on Italian versions which can be used as a standalone ACE species.

--- a/content/frlg-non-jpn-post-e4-route.md
+++ b/content/frlg-non-jpn-post-e4-route.md
@@ -137,6 +137,15 @@ If you see this, that means you have successfully set up ACE! Continue reading t
 
 ![The Pokémon PC interface with the cursor hovering over a question mark. The black and white circled question mark has an unintelligible name, is male, and level 100.](assets/images/frlg/getting-started/non-jpn-ace/0351-in-box.png)
 
+<div class="admonition note" markdown="block">
+<p class="admonition-title">Note</p>
+
+The glitch Pokémon’s icon may not appear exactly as shown in the screenshots, this is normal.
+Glitch Pokémon in FireRed and LeafGreen will usually appear either as another Pokémon in the boxes with a different color palette, or as a question mark.
+More information about this can be found at [this FAQ](frlg-faq.md#the-glitch-pokémon-has-a-different-box-sprite).
+
+</div>
+
 ## Appendix
 
 ### How to trigger ACE

--- a/content/frlg-non-jpn-post-e4-route.md
+++ b/content/frlg-non-jpn-post-e4-route.md
@@ -144,6 +144,9 @@ The glitch Pokémon’s icon may not appear exactly as shown in the screenshots,
 Glitch Pokémon in FireRed and LeafGreen will usually appear either as another Pokémon in the boxes with a different color palette, or as a question mark.
 More information about this can be found at [this FAQ](frlg-faq.md#the-glitch-pokémon-has-a-different-box-sprite).
 
+This glitch Pokémon does not `hasSpecies` set, it will disappear if you include it in a group selection.
+More information can be found at [this FAQ](general-faq.md#my-pokémonegg-is-disappearing-when-i-move-them).
+
 </div>
 
 ## Appendix

--- a/content/frlg-non-jpn-pre-e4-route.md
+++ b/content/frlg-non-jpn-pre-e4-route.md
@@ -272,6 +272,15 @@ After confirming this message, check Box 3, Slot 1. The 0x0200 should have becom
 
 ![The Pokémon PC interface with the cursor hovering over a question mark. The black and white circled question mark has an unintelligible name, is male, and level 100.](assets/images/frlg/getting-started/non-jpn-ace/0351-in-box.png)
 
+<div class="admonition note" markdown="block">
+<p class="admonition-title">Note</p>
+
+The glitch Pokémon’s icon may not appear exactly as shown in the screenshots, this is normal.
+Glitch Pokémon in FireRed and LeafGreen will usually appear either as another Pokémon in the boxes with a different color palette, or as a question mark.
+More information about this can be found at [this FAQ](frlg-faq.md#the-glitch-pokémon-has-a-different-box-sprite).
+
+</div>
+
 ## Appendix
 
 ### How to trigger ACE

--- a/content/frlg-non-jpn-pre-e4-route.md
+++ b/content/frlg-non-jpn-pre-e4-route.md
@@ -153,6 +153,14 @@ After confirming the message, a glitch species should appear in Box 3, Slot 1. T
 
 If the glitch species does not have the correct name, or a bad egg appeared instead, do the glitched mail message again, and make sure that Box 3, Slot 1 is **empty**.
 
+<div class="admonition note" markdown="block">
+<p class="admonition-title">Note</p>
+
+This Pokémon (and the ACE species generated from it) does not `hasSpecies` set, it will disappear if you include it in a group selection.
+More information can be found at [this FAQ](general-faq.md#my-pokémonegg-is-disappearing-when-i-move-them).
+
+</div>
+
 Move glitch species 0x0200 into your party then give it:
 
 *   **8** HP Ups

--- a/content/general-faq.md
+++ b/content/general-faq.md
@@ -281,6 +281,29 @@ for alternate methods to delete these particular invisible bad eggs.
 
 ![Orange hand grabbing a group of Pokémon from one box to the next](assets/images/faq/group_select.gif)
 
+## My Pokémon/Egg is disappearing when I move them
+
+This means that the Pokémon or Egg does not have the `hasSpecies` flag
+set in its data. They will generally disappear if you try moving them
+using group selection, which is selection of multiple Pokémon using the
+orange cursor.
+
+Moving a single Pokémon/Egg with the orange cursor or the white cursor
+will generally not make the Pokémon or egg disappear, so use these for
+moving Pokémon/Eggs that might potentially disappear with group selection.
+
+For eggs, if you hatch them, the game will set the hasSpecies flag in
+the hatched Pokémon's data which means it will not be affected by
+disappearance issues caused by group selection.
+
+These Pokémon/Egg are known to be generated without `hasSpecies` set:
+
+*   Anything generated from an empty slot using the question mark Mail.
+*   ACE species created using the [ACE3](https://e-sh4rk.github.io/ACE3/) guide before mid-2025.
+*   The [Certificate Exit Bootstrap] created using the [ACE3](https://e-sh4rk.github.io/ACE3/) guide.
+*   Eggs created with the <i>Create 6IV Egg from Nothing</i> code.
+*   Eggs created with the <i>Create Egg with Custom Hidden Power</i> code.
+
 ## How can I make my own ACE code?
 
 For all ACE methods, you must know some ARM/Thumb assembly. The below

--- a/content/mail-glitch.md
+++ b/content/mail-glitch.md
@@ -351,6 +351,11 @@ This allows for changing the substructure order, encryption key, nature, and gen
 Changing the substructure order allows you to easily modify the an existing Pokémon in Box 3, Slot 1.
 Changing the encryption key allows you to create Pokémon directly from an empty slot.
 
+Pokémon and eggs created from an empty slot using the question mark Mail will not have `hasSpecies` set.
+This means that including these in a group selection will cause them to disappear.
+Pokémon hatched from eggs generated with this method will have `hasSpecies` set, meaning they can be included in a group selection without issue.
+More information can be found at [this FAQ](general-faq.md#my-pokémonegg-is-disappearing-when-i-move-them).
+
 Papa Jefé has a [comprehensive video tutorial](https://youtu.be/3jkcq8e9NO4?t=1805) utilising the <abbr title="question mark Mail">QMM</abbr> in this manner.
 
 #### Japanese FireRed and LeafGreen


### PR DESCRIPTION
Added FAQ entries for disappearing Pokémon and the glitch Pokémon icons in FireRed and LeafGreen. Additional notes have been created in relevant pages regarding `hasSpecies` and the icons.

Close #33